### PR TITLE
Subpackage dialog added pages (2,3,4,5,7) validations

### DIFF
--- a/rpg/gui/dialogs.py
+++ b/rpg/gui/dialogs.py
@@ -1,7 +1,8 @@
 from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtWidgets import (QLabel, QPushButton, QPlainTextEdit,
                              QDialogButtonBox, QLineEdit, QVBoxLayout,
-                             QCalendarWidget, QHBoxLayout, QFileDialog)
+                             QCalendarWidget, QHBoxLayout, QFileDialog,
+                             QComboBox)
 
 
 class DialogChangelog(QtWidgets.QDialog):
@@ -136,6 +137,53 @@ class DialogSRPM(QtWidgets.QDialog):
         ''' If user clicked "Edit" button'''
         brows = QFileDialog()
         brows.getOpenFileName(self, "/home")
+
+    def acceptIt(self):
+        ''' If user clicked "OK" button '''
+        self.accept()
+
+
+class DialogSubpackage(QtWidgets.QDialog):
+    def __init__(self, Dialog, Wizard, parent=None):
+        super(DialogSubpackage, self).__init__(parent)
+
+                # Settings
+        self.setMinimumSize(QtCore.QSize(350, 150))
+        self.setMaximumSize(QtCore.QSize(500, 600))
+
+        # Setting labels
+        nameLabel = QLabel("Name")
+        groupLabel = QLabel("Group")
+        summaryLabel = QLabel("Summary")
+        descriptionLabel = QLabel("Description")
+
+        # Setting text editors
+        self.nameEdit = QLineEdit()
+        self.groupEdit = QComboBox()
+        self.summaryEdit = QLineEdit()
+        self.descriptionEdit = QPlainTextEdit()
+
+        # Setting buttons
+        self.okButton = QPushButton("OK")
+        self.cancelButton = QPushButton("Cancel")
+        self.boxButtons = QDialogButtonBox(parent=Wizard)
+        self.boxButtons.addButton(self.okButton, 0)
+        self.boxButtons.addButton(self.cancelButton, 1)
+        self.boxButtons.accepted.connect(self.acceptIt)
+        self.boxButtons.rejected.connect(self.reject)
+
+        # Setting layout
+        mainLayout = QVBoxLayout()
+        mainLayout.addWidget(nameLabel)
+        mainLayout.addWidget(self.nameEdit)
+        mainLayout.addWidget(groupLabel)
+        mainLayout.addWidget(self.groupEdit)
+        mainLayout.addWidget(summaryLabel)
+        mainLayout.addWidget(self.summaryEdit)
+        mainLayout.addWidget(descriptionLabel)
+        mainLayout.addWidget(self.descriptionEdit)
+        mainLayout.addWidget(self.boxButtons)
+        self.setLayout(mainLayout)
 
     def acceptIt(self):
         ''' If user clicked "OK" button '''

--- a/rpg/gui/wizard.py
+++ b/rpg/gui/wizard.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import (QLabel, QVBoxLayout, QLineEdit, QCheckBox,
                              QGroupBox, QComboBox, QPushButton, QGridLayout,
                              QPlainTextEdit, QListWidget, QHBoxLayout,
                              QDialog, QFileDialog)
-from rpg.gui.dialogs import DialogChangelog
+from rpg.gui.dialogs import DialogChangelog, DialogSubpackage
 from rpg import Base
 
 
@@ -170,7 +170,9 @@ class ImportPage(QtWidgets.QWizardPage):
     def openImportPageFileDialog(self):
         ''' Open file browser in new dialog window'''
         brows = QFileDialog()
-        brows.getOpenFileName(self, "/home")
+        #brows.setFileMode(QFileDialog.Directory)
+        brows.getExistingDirectory(self, "Choose source folder or archive",
+                                   "~/")
 
     def validatePage(self):
         ''' [Bool] Function that invokes just after pressing the next button
@@ -185,7 +187,7 @@ class ImportPage(QtWidgets.QWizardPage):
         self.base.spec.tags['URL'] = self.URLEdit.text()
         self.base.spec.tags['Group'] = self.groupEdit.currentText()
         self.base.spec.tags['Summary'] = self.summaryEdit.text()
-        self.base.spec.tags['%description'] = self.descriptionEdit.text()
+        self.base.spec.scripts['%description'] = self.descriptionEdit.text()
         self.base.spec.tags['Vendor'] = self.vendorEdit.text()
         self.base.spec.tags['Packager'] = self.packagerEdit.text()
         self.base.spec.tags['Path'] = self.importEdit.text()
@@ -233,10 +235,10 @@ class ScriptsPage(QtWidgets.QWizardPage):
         self.setLayout(grid)
 
     def validatePage(self):
-        self.base.spec.tags['%prep'] = self.prepareEdit.toPlainText()
-        self.base.spec.tags['%build'] = self.buildEdit.toPlainText()
-        self.base.spec.tags['%install'] = self.installEdit.toPlainText()
-        self.base.spec.tags['%check'] = self.checkEdit.toPlainText()
+        self.base.spec.scripts['%prep'] = self.prepareEdit.toPlainText()
+        self.base.spec.scripts['%build'] = self.buildEdit.toPlainText()
+        self.base.spec.scripts['%install'] = self.installEdit.toPlainText()
+        self.base.spec.scripts['%check'] = self.checkEdit.toPlainText()
         return True
 
     def nextId(self):
@@ -360,12 +362,12 @@ class ScripletsPage(QtWidgets.QWizardPage):
         self.setLayout(grid)
 
     def validatePage(self):
-        self.base.spec.tags["%pretrans"] = self.pretransEdit.toPlainText()
-        self.base.spec.tags["%pre"] = self.preEdit.toPlainText()
-        self.base.spec.tags["%post"] = self.postEdit.toPlainText()
-        self.base.spec.tags["%postun"] = self.postunEdit.toPlainText()
-        self.base.spec.tags["%preun"] = self.preunEdit.toPlainText()
-        self.base.spec.tags["%posttrans"] = self.posttransEdit.toPlainText()
+        self.base.spec.scripts["%pretrans"] = self.pretransEdit.toPlainText()
+        self.base.spec.scripts["%pre"] = self.preEdit.toPlainText()
+        self.base.spec.scripts["%post"] = self.postEdit.toPlainText()
+        self.base.spec.scripts["%postun"] = self.postunEdit.toPlainText()
+        self.base.spec.scripts["%preun"] = self.preunEdit.toPlainText()
+        self.base.spec.scripts["%posttrans"] = self.posttransEdit.toPlainText()
         return True
 
     def nextId(self):
@@ -387,6 +389,7 @@ class SubpackagesPage(QtWidgets.QWizardPage):
         self.addPackButton = QPushButton("+")
         self.addPackButton.setMaximumWidth(68)
         self.addPackButton.setMaximumHeight(60)
+        self.addPackButton.clicked.connect(self.openSubpackageDialog)
 
         self.removePackButton = QPushButton("-")
         self.removePackButton.setMaximumWidth(68)
@@ -414,6 +417,11 @@ class SubpackagesPage(QtWidgets.QWizardPage):
         mainLayout.addLayout(upperLayout)
         mainLayout.addLayout(lowerLayout)
         self.setLayout(mainLayout)
+
+    def openSubpackageDialog(self):
+        subpackageWindow = QDialog()
+        subpackage = DialogSubpackage(subpackageWindow, self)
+        subpackage.exec_()
 
     def nextId(self):
         return Wizard.PageDocsChangelog
@@ -555,7 +563,10 @@ class BuildPage(QtWidgets.QWizardPage):
         self.setLayout(mainLayout)
 
     def validatePage(self):
+        print(" ---- Tags: ---- ")
         print(self.base.spec.tags)
+        print("\n ----- Scripts: ----- ")
+        print(self.base.spec.scripts)
         return True
 
     def switchToCOPR(self):
@@ -670,7 +681,7 @@ class FinalPage(QtWidgets.QWizardPage):
         self.setTitle(self.tr("Final page"))
         self.setSubTitle(self.tr("Your package was successfully created"))
         finalLabel = QLabel("<html><head/><body><p align=\"center\"><span" +
-                            "style=\" font-size:24pt;\">Thank you for" +
+                            "style=\" font-size:24pt;\">Thank you for " +
                             "using RPG!</span></p><p align=\"center\">" +
                             "<span style=\" font-size:24pt;\">Your" +
                             " package was built in:</span></p></body></html>")


### PR DESCRIPTION
From state diagram I forgot about dialog for adding subpackages. Now it's there and also works validation of 2,3,4,5,7 pages of wizard. There is an output of 'tags' and 'scripts' those are saved in Base() classes object after switching from "Build page" to "Finish page". There is also a filter on 2nd page of wizard for importing sources (file dialog) - now user can choose only dir. 
