### PR TITLE
CMakeLists.txt and rpg.spec added #20 #97

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,84 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 3.0)
+PROJECT (RPG)
+
+# Python search:
+# FIND_PACKAGE (PythonLibs 3.0) doesn't work properly
+FIND_PACKAGE (PythonInterp 3.4 REQUIRED)
+
+# QT5 search:
+EXECUTE_PROCESS (COMMAND bash -c "find /lib64 /usr /lib /etc -name qt5 2>/dev/null | tr '\n' ' '" OUTPUT_VARIABLE QT5_SEARCH)
+IF (QT5_SEARCH)
+    MESSAGE (STATUS "QT5 exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "QT5 is missing!")
+ENDIF ()
+
+# QT5Base search:
+EXECUTE_PROCESS (COMMAND bash -c "find /lib64 /usr /lib /etc -path '*qt5*qtbase*' 2>/dev/null | tr '\n' ' '" OUTPUT_VARIABLE QT5BASE_SEARCH)
+IF (QT5BASE_SEARCH)
+    MESSAGE (STATUS "QT5Base exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "QT5Base is missing!")
+ENDIF ()
+
+# Python3QT5 search:
+EXECUTE_PROCESS (COMMAND bash -c "find /lib64 /usr /lib /etc -name python3-qt5 2>/dev/null | tr '\n' ' '" OUTPUT_VARIABLE PYTHON3QT5_SEARCH)
+IF (PYTHON3QT5_SEARCH)
+    MESSAGE (STATUS "Python3QT5 exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "Python3QT5 is missing!")
+ENDIF ()
+
+# Makedepend search:
+FIND_PROGRAM (MakeDepProg makedepend)
+IF (MakeDepProg)
+    MESSAGE (STATUS "Makedepend exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "Makedepend is missing!")
+ENDIF ()
+
+# file search:
+FIND_PROGRAM (FileProg file)
+IF (FileProg)
+    MESSAGE (STATUS "File exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "File is missing!")
+ENDIF ()
+
+# coreutils search:
+EXECUTE_PROCESS (COMMAND bash -c "find /lib64 /usr /lib /etc -name coreutils 2>/dev/null | tr '\n' ' '" OUTPUT_VARIABLE COREUTILS_SEARCH)
+IF (COREUTILS_SEARCH)
+    MESSAGE (STATUS "CoreUtils exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "CoreUtils is missing!")
+ENDIF ()
+
+# rpmdevtools search:
+EXECUTE_PROCESS (COMMAND bash -c "find /lib64 /usr /lib /etc -path '*rpmdevtools' 2>/dev/null | tr '\n' ' '" OUTPUT_VARIABLE RPMDEVTOOLS_SEARCH)
+IF (RPMDEVTOOLS_SEARCH)
+    MESSAGE (STATUS "Rpm developer tools exists")
+ELSE ()
+    MESSAGE (FATAL_ERROR "Rpm developer tools is missing!")
+ENDIF ()
+
+# Nosetests search:
+SET (NoseProg)
+FIND_PROGRAM (NoseProg nosetests-3.4)
+IF (NoseProg)
+    MESSAGE (STATUS "Nosestests exists")
+    ENABLE_TESTING ()
+    FILE (GLOB tests "./tests/test_*.py")
+    FOREACH (file ${tests})
+        ADD_TEST (NAME ${file} COMMAND nosetests-3.4 ${file})
+    ENDFOREACH ()
+ELSE ()
+    MESSAGE (WARNING "Nosetests is missing! - no tests available")
+ENDIF ()
+
+# Set install directory:
+EXECUTE_PROCESS (COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib())" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+MESSAGE (STATUS "Installing to dir '${PYTHON_INSTALL_DIR}'")
+
+# Installation:
+ADD_SUBDIRECTORY (rpg)
+INSTALL (PROGRAMS "RPG.py" DESTINATION bin RENAME rpg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ CMAKE_MINIMUM_REQUIRED (VERSION 3.0)
 PROJECT (RPG)
 
 # Python search:
-# FIND_PACKAGE (PythonLibs 3.0) doesn't work properly
 FIND_PACKAGE (PythonInterp 3.4 REQUIRED)
 
 # QT5 search:
@@ -61,18 +60,18 @@ ELSE ()
     MESSAGE (FATAL_ERROR "Rpm developer tools is missing!")
 ENDIF ()
 
-# Nosetests search:
-SET (NoseProg)
-FIND_PROGRAM (NoseProg nosetests-3.4)
-IF (NoseProg)
-    MESSAGE (STATUS "Nosestests exists")
-    ENABLE_TESTING ()
-    FILE (GLOB tests "./tests/test_*.py")
-    FOREACH (file ${tests})
-        ADD_TEST (NAME ${file} COMMAND nosetests-3.4 ${file})
-    ENDFOREACH ()
+# nosetests search:
+IF (EXISTS ${PROJECT_SOURCE_DIR}/tests)
+    FIND_PROGRAM (NoseProg nosetests-3.4)
+    IF (NoseProg)
+        MESSAGE (STATUS "Nosestests exists")
+        ENABLE_TESTING ()
+        ADD_SUBDIRECTORY (tests)
+    ELSE ()
+        MESSAGE (WARNING "Nosetests is missing! - no tests available")
+    ENDIF ()
 ELSE ()
-    MESSAGE (WARNING "Nosetests is missing! - no tests available")
+    MESSAGE (WARNING "No tests available")
 ENDIF ()
 
 # Set install directory:

--- a/clean
+++ b/clean
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . \( -name '*.cmake' -o -name Makefile -o -name CMakeFiles -o -name CMakeCache.txt \) -exec rm -rf {} \;

--- a/clean
+++ b/clean
@@ -1,2 +1,0 @@
-#!/bin/bash
-find . \( -name '*.cmake' -o -name Makefile -o -name CMakeFiles -o -name CMakeCache.txt \) -exec rm -rf {} \;

--- a/rpg.spec
+++ b/rpg.spec
@@ -1,0 +1,112 @@
+Name:           RPG
+Version:        0.1
+Release:        1%{?snapshot}%{?dist}
+Summary:        RPM Package Generator
+#Group:
+License:        GNU
+#URL:
+Source:         %{name}-%{version}.tar.gz
+BuildRequires:  cmake
+BuildRequires:  python3-devel
+BuildArch:      noarch
+
+Requires:       python3 >= 3.4
+Requires:       python3-qt5
+Requires:       qt5-qtbase-gui
+Requires:       coreutils
+Requires:       file
+Requires:       makedepend
+Requires:       rpmdevtools
+
+%description
+RPG is tool, that guides people through the creation of a RPM
+package. RPG makes packaging much easier due to the automatic analysis of
+packaged files. Beginners can get familiar with packaging process or the
+advanced users can use our tool for a quick creation of a package.
+
+%prep
+%autosetup
+
+%build
+%cmake .
+
+%install
+make install DESTDIR=%{RPM_BUILD_ROOT}
+%make_install
+
+%check
+make test
+
+%files
+%{_bindir}/rpg
+%{python3_sitelib}/rpg/__init__.py
+%{python3_sitelib}/rpg/command.py
+%{python3_sitelib}/rpg/conf.py
+%{python3_sitelib}/rpg/copr_uploader.py
+%{python3_sitelib}/rpg/gui/dialogs.py
+%{python3_sitelib}/rpg/gui/wizard.py
+%{python3_sitelib}/rpg/package_builder.py
+%{python3_sitelib}/rpg/plugin.py
+%{python3_sitelib}/rpg/plugin_engine.py
+%{python3_sitelib}/rpg/plugins/lang/c.py
+%{python3_sitelib}/rpg/plugins/lang/python.py
+%{python3_sitelib}/rpg/plugins/misc/find_changelog.py
+%{python3_sitelib}/rpg/plugins/misc/find_file.py
+%{python3_sitelib}/rpg/plugins/misc/find_library.py
+%{python3_sitelib}/rpg/plugins/misc/find_patch.py
+%{python3_sitelib}/rpg/plugins/misc/find_translation.py
+%{python3_sitelib}/rpg/plugins/project_builder/autotools.py
+%{python3_sitelib}/rpg/plugins/project_builder/cmake.py
+%{python3_sitelib}/rpg/plugins/project_builder/make.py
+%{python3_sitelib}/rpg/project_builder.py
+%{python3_sitelib}/rpg/source_loader.py
+%{python3_sitelib}/rpg/spec.py
+%{python3_sitelib}/rpg/utils.py
+%{python3_sitelib}/rpg/__pycache__/__init__.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/__init__.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/command.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/command.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/conf.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/conf.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/copr_uploader.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/copr_uploader.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/package_builder.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/package_builder.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/plugin.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/plugin.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/plugin_engine.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/plugin_engine.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/project_builder.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/project_builder.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/source_loader.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/source_loader.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/spec.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/spec.cpython-34.pyo
+%{python3_sitelib}/rpg/__pycache__/utils.cpython-34.pyc
+%{python3_sitelib}/rpg/__pycache__/utils.cpython-34.pyo
+%{python3_sitelib}/rpg/gui/__pycache__/dialogs.cpython-34.pyc
+%{python3_sitelib}/rpg/gui/__pycache__/dialogs.cpython-34.pyo
+%{python3_sitelib}/rpg/gui/__pycache__/wizard.cpython-34.pyc
+%{python3_sitelib}/rpg/gui/__pycache__/wizard.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/lang/__pycache__/c.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/lang/__pycache__/c.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/lang/__pycache__/python.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/lang/__pycache__/python.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_changelog.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_changelog.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_file.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_file.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_library.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_library.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_patch.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_patch.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_translation.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_translation.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/autotools.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/autotools.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/cmake.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/cmake.cpython-34.pyo
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/make.cpython-34.pyc
+%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/make.cpython-34.pyo
+
+%changelog

--- a/rpg.spec
+++ b/rpg.spec
@@ -1,10 +1,9 @@
 Name:           RPG
-Version:        0.1
+Version:        0.0.1
 Release:        1%{?snapshot}%{?dist}
 Summary:        RPM Package Generator
-#Group:
-License:        GNU
-#URL:
+License:        GPLv2
+URL:            https://github.com/rh-lab-q/rpg
 Source:         %{name}-%{version}.tar.gz
 BuildRequires:  cmake
 BuildRequires:  python3-devel
@@ -39,74 +38,6 @@ make test
 
 %files
 %{_bindir}/rpg
-%{python3_sitelib}/rpg/__init__.py
-%{python3_sitelib}/rpg/command.py
-%{python3_sitelib}/rpg/conf.py
-%{python3_sitelib}/rpg/copr_uploader.py
-%{python3_sitelib}/rpg/gui/dialogs.py
-%{python3_sitelib}/rpg/gui/wizard.py
-%{python3_sitelib}/rpg/package_builder.py
-%{python3_sitelib}/rpg/plugin.py
-%{python3_sitelib}/rpg/plugin_engine.py
-%{python3_sitelib}/rpg/plugins/lang/c.py
-%{python3_sitelib}/rpg/plugins/lang/python.py
-%{python3_sitelib}/rpg/plugins/misc/find_changelog.py
-%{python3_sitelib}/rpg/plugins/misc/find_file.py
-%{python3_sitelib}/rpg/plugins/misc/find_library.py
-%{python3_sitelib}/rpg/plugins/misc/find_patch.py
-%{python3_sitelib}/rpg/plugins/misc/find_translation.py
-%{python3_sitelib}/rpg/plugins/project_builder/autotools.py
-%{python3_sitelib}/rpg/plugins/project_builder/cmake.py
-%{python3_sitelib}/rpg/plugins/project_builder/make.py
-%{python3_sitelib}/rpg/project_builder.py
-%{python3_sitelib}/rpg/source_loader.py
-%{python3_sitelib}/rpg/spec.py
-%{python3_sitelib}/rpg/utils.py
-%{python3_sitelib}/rpg/__pycache__/__init__.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/__init__.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/command.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/command.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/conf.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/conf.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/copr_uploader.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/copr_uploader.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/package_builder.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/package_builder.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/plugin.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/plugin.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/plugin_engine.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/plugin_engine.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/project_builder.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/project_builder.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/source_loader.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/source_loader.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/spec.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/spec.cpython-34.pyo
-%{python3_sitelib}/rpg/__pycache__/utils.cpython-34.pyc
-%{python3_sitelib}/rpg/__pycache__/utils.cpython-34.pyo
-%{python3_sitelib}/rpg/gui/__pycache__/dialogs.cpython-34.pyc
-%{python3_sitelib}/rpg/gui/__pycache__/dialogs.cpython-34.pyo
-%{python3_sitelib}/rpg/gui/__pycache__/wizard.cpython-34.pyc
-%{python3_sitelib}/rpg/gui/__pycache__/wizard.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/lang/__pycache__/c.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/lang/__pycache__/c.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/lang/__pycache__/python.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/lang/__pycache__/python.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_changelog.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_changelog.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_file.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_file.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_library.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_library.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_patch.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_patch.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_translation.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/misc/__pycache__/find_translation.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/autotools.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/autotools.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/cmake.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/cmake.cpython-34.pyo
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/make.cpython-34.pyc
-%{python3_sitelib}/rpg/plugins/project_builder/__pycache__/make.cpython-34.pyo
+%{python3_sitelib}/rpg/
 
 %changelog

--- a/rpg/CMakeLists.txt
+++ b/rpg/CMakeLists.txt
@@ -1,0 +1,5 @@
+FILE (GLOB rpg_srcs *.py)
+INSTALL (FILES ${rpg_srcs} DESTINATION ${PYTHON_INSTALL_DIR}/rpg)
+
+ADD_SUBDIRECTORY (gui)
+ADD_SUBDIRECTORY (plugins)

--- a/rpg/gui/CMakeLists.txt
+++ b/rpg/gui/CMakeLists.txt
@@ -1,0 +1,2 @@
+FILE (GLOB rpg_gui_srcs *.py)
+INSTALL (FILES ${rpg_gui_srcs} DESTINATION ${PYTHON_INSTALL_DIR}/rpg/gui)

--- a/rpg/plugins/CMakeLists.txt
+++ b/rpg/plugins/CMakeLists.txt
@@ -1,0 +1,3 @@
+ADD_SUBDIRECTORY (lang)
+ADD_SUBDIRECTORY (misc)
+ADD_SUBDIRECTORY (project_builder)

--- a/rpg/plugins/lang/CMakeLists.txt
+++ b/rpg/plugins/lang/CMakeLists.txt
@@ -1,0 +1,2 @@
+FILE (GLOB rpg_lang_srcs *.py)
+INSTALL (FILES ${rpg_lang_srcs} DESTINATION ${PYTHON_INSTALL_DIR}/rpg/plugins/lang)

--- a/rpg/plugins/misc/CMakeLists.txt
+++ b/rpg/plugins/misc/CMakeLists.txt
@@ -1,0 +1,2 @@
+FILE (GLOB rpg_misc_srcs *.py)
+INSTALL (FILES ${rpg_misc_srcs} DESTINATION ${PYTHON_INSTALL_DIR}/rpg/plugins/misc)

--- a/rpg/plugins/project_builder/CMakeLists.txt
+++ b/rpg/plugins/project_builder/CMakeLists.txt
@@ -1,0 +1,2 @@
+FILE (GLOB rpg_proj_builder_srcs *.py)
+INSTALL (FILES ${rpg_proj_builder_srcs} DESTINATION ${PYTHON_INSTALL_DIR}/rpg/plugins/project_builder)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+FILE (GLOB files test_*.py)
+FOREACH (file ${files})
+    ADD_TEST(${file} nosetests-3.4 ${file} -w ${PROJECT_SOURCE_DIR})
+ENDFOREACH ()


### PR DESCRIPTION
Inspired by https://github.com/rpm-software-management/dnf.

Installation works fine, but there is a bug. When you install rpg, first run will do nothing, but on another tries it will run properly. 

Checking packages was real problem, I had to improvised, because CMake didn't find them, so I use ```find``` to search for some of them. On my fedora 21 it works fine.

I have chosen to use dnf installation directory, which is ```/usr/lib/python3.4/site-packages```. It can be changed later.

CMake doesn't have uninstall or clean. So I have made cleaning script ```./clean``` that removes all thrash that CMake creates.

```nosetests-3.4``` is connected to CMake. It runs tests file by file in tests directory. Output of tests are in ```./Testing/Temporary``` directory.

Here is example of using CMake to install RPG:
```
cmake .
make test
sudo make install
./clean
```