### PR TITLE
spec file: redundant python3-copr removed

### DIFF
--- a/rpg.spec
+++ b/rpg.spec
@@ -10,7 +10,6 @@ BuildRequires:  python3-nose
 BuildRequires:  python3-devel
 BuildRequires:  python3 >= 3.4
 BuildRequires:  python3-qt5
-BuildRequires:  python3-copr
 BuildRequires:  qt5-qtbase-gui
 BuildRequires:  coreutils
 BuildRequires:  file


### PR DESCRIPTION
There were two "python3-copr" in BuildRequires