### PR TITLE
Setuptools plugin and test (fix #131)

### DIFF
--- a/rpg/plugins/project_builder/setuptools.py
+++ b/rpg/plugins/project_builder/setuptools.py
@@ -1,0 +1,15 @@
+from rpg.command import Command
+from rpg.plugin import Plugin
+import logging
+
+
+class SetuptoolsPlugin(Plugin):
+
+    def patched(self, project_dir, spec, sack):
+        if (project_dir / "setup.py").is_file():
+            spec.BuildRequires.add("python3-setuptools")
+            logging.debug('setup.py found')
+            spec.build = Command("python3 setup.py build")
+            spec.install = Command(
+                "python3 setup.py install "
+                "--skip-build --root $RPM_BUILD_ROOT")

--- a/tests/project/setuptools/setup.py
+++ b/tests/project/setuptools/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+setup(
+    name="SetupToolsTestProject",
+    version="0.1",
+    packages=find_packages(),
+    scripts=['testscript.py'],
+)

--- a/tests/project/setuptools/testscript.py
+++ b/tests/project/setuptools/testscript.py
@@ -1,0 +1,1 @@
+print("This is just a test")

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -11,6 +11,7 @@ from rpg.plugins.lang.c import CPlugin
 from rpg.spec import Spec
 from unittest import mock
 from rpg.plugins.project_builder.cmake import CMakePlugin
+from rpg.plugins.project_builder.setuptools import SetuptoolsPlugin
 
 
 class MockSack:
@@ -88,7 +89,9 @@ class FindPatchPluginTest(PluginTestCase):
                  ('/Makefile', None, None),
                  ('/py/requires/sourcecode2.py', None, None),
                  ('/mock_project/mock-1.0.tar.gz', None, None),
-                 ('/c/CMakeCache.txt', None, None)]
+                 ('/c/CMakeCache.txt', None, None),
+                 ('/setuptools/setup.py', None, None),
+                 ('/setuptools/testscript.py', None, None)]
         excludes = [('/patch/__pycache__/', r'%exclude', None),
                     ('/c/__pycache__/', r'%exclude', None),
                     ('/hello_project/__pycache__/', r'%exclude', None),
@@ -99,7 +102,8 @@ class FindPatchPluginTest(PluginTestCase):
                     ('/archives/__pycache__/', r'%exclude', None),
                     ('/__pycache__/', r'%exclude', None),
                     ('/srpm/__pycache__/', '%exclude', None),
-                    ('/mock_project/__pycache__/', '%exclude', None)]
+                    ('/mock_project/__pycache__/', '%exclude', None),
+                    ('/setuptools/__pycache__/', '%exclude', None)]
         sorted_files = sorted(files + excludes, key=lambda e: e[0])
         self.assertEqual(self.spec.files,
                          sorted_files)
@@ -168,3 +172,13 @@ class FindPatchPluginTest(PluginTestCase):
         cmakeplug.compiled(self.test_project_dir / "c", self.spec, self.sack)
         self.assertEqual(self.spec.build_required_files, expected)
         self.assertEqual(self.spec.required_files, expected)
+
+    def test_setuptools(self):
+        setuptplug = SetuptoolsPlugin()
+        setuptplug.patched(
+            self.test_project_dir / "setuptools", self.spec, self.sack)
+        self.assertEqual(self.spec.BuildRequires, {"python3-setuptools"})
+        self.assertEqual(str(self.spec.build), "python3 setup.py build")
+        self.assertEqual(
+            str(self.spec.install),
+            "python3 setup.py install --skip-build --root $RPM_BUILD_ROOT")


### PR DESCRIPTION
I tested it on primitive project with minimal setuptools functionality (`setup.py` file + one script) and it went well. `FindFilePlugin` managed to find all `spec.required_files` and `spec.buildrequired_files` (all files in `*.egg-info` directory and modul directory) so in my opinion *setuptools plugin* does not need to do this itself.

I will try to build *python-requests* to see if it works on larger scale