### PR TITLE
Autotools plugin + bug fixes + cmake plugin upgrade (fix #15, #271, #272, #256)

### DIFF
--- a/rpg/gui/wizard.py
+++ b/rpg/gui/wizard.py
@@ -539,10 +539,10 @@ class RequiresPage(QtWidgets.QWizardPage):
         self.base.spec.BuildRequires = self.bRequiresEdit.toPlainText()
         self.base.spec.Requires = self.requiresEdit.toPlainText()
         self.base.spec.Provides = self.providesEdit.toPlainText()
-        self.base.spec.BuildRequires = self.base.spec.\
-            BuildRequires.splitlines()
-        self.base.spec.Requires = self.base.spec.Requires.splitlines()
-        self.base.spec.Provides = self.base.spec.Provides.splitlines()
+        self.base.spec.BuildRequires = set(
+            self.base.spec.BuildRequires.splitlines())
+        self.base.spec.Requires = set(self.base.spec.Requires.splitlines())
+        self.base.spec.Provides = set(self.base.spec.Provides.splitlines())
         return True
 
     def nextId(self):

--- a/rpg/plugins/misc/find_file.py
+++ b/rpg/plugins/misc/find_file.py
@@ -19,4 +19,4 @@ class FindFilePlugin(Plugin):
                                for key in self.exclude],
                               key=lambda e: e[0])
         for one_file in sorted_files:
-            spec.files.append(one_file)
+            spec.files.add(one_file)

--- a/rpg/plugins/misc/find_translation.py
+++ b/rpg/plugins/misc/find_translation.py
@@ -6,5 +6,5 @@ class FindTranslationPlugin(Plugin):
     def installed(self, project_dir, spec, sack):
         translation_file = list(project_dir.glob('**/*.mo'))
         if translation_file and translation_file[0].is_file():
-            spec.files.insert(0, (("-f %%{%s}.lang"
-                                   % translation_file[0].name), None, None))
+            spec.files.add((("-f %%{%s}.lang"
+                             % translation_file[0].name), None, None))

--- a/rpg/plugins/project_builder/autotools.py
+++ b/rpg/plugins/project_builder/autotools.py
@@ -1,0 +1,60 @@
+from rpg.command import Command
+from rpg.plugin import Plugin
+import logging
+import re
+
+
+class AutotoolsPlugin(Plugin):
+
+    def patched(self, project_dir, spec, sack):
+        if (project_dir / "configure").is_file():
+            logging.debug('configure found')
+            build = Command()
+            build.append("./configure")
+            build.append("make")
+            spec.build = build
+            spec.install = Command("make install DESTDIR=$RPM_BUILD_ROOT")
+        elif ((project_dir / "configure.ac").is_file() and
+              (project_dir / "Makefile.am").is_file()):
+            logging.debug('configure.ac and Makefile.am found')
+            spec.BuildRequires.add("autoconf")
+            spec.BuildRequires.add("automake")
+            spec.BuildRequires.add("libtool")
+            f = (project_dir / "configure.ac").open()
+            regex = re.compile(
+                r"PKG_CHECK_MODULES\s*\(.*?,\s*(.*?)\s*?[,\)]", re.DOTALL)
+            deps = _extract_dependencies(regex, f)
+            for dep in deps:
+                spec.BuildRequires.add(dep)
+            build = Command()
+            if (project_dir / "autogen.sh").is_file():
+                logging.debug('autogen.sh found')
+                build.append("./autogen.sh")
+            else:
+                build.append("autoreconf --install --force")
+            build.append("./configure")
+            build.append("make")
+            spec.build = build
+            spec.install = Command("make install DESTDIR=$RPM_BUILD_ROOT")
+        elif (project_dir / "configure.ac").is_file():
+            logging.warning('configure.ac found, Makefile.am missing')
+        elif (project_dir / "Makefile.am").is_file():
+            logging.warning('Makefile.am found, configure.ac missing')
+
+
+def _extract_dependencies(regex, file):
+    regex2 = re.compile(r"\[?\s*(\S*\s*[><=]+\s*[^\s\]]*|[^\s\]]+)\s*\]?")
+    file.seek(0)
+    temps = []
+    deps = []
+    matches = regex.findall(file.read())
+    for match in matches:
+        temps += list(regex2.findall(match))
+    for temp in temps:
+        if temp[0] == '$':
+            regex3 = re.compile(
+                temp[1:] + r"\s*=\s*[\"\[]\s*(.*?)\s*?[\]\"]", re.DOTALL)
+            deps += list(_extract_dependencies(regex3, file))
+        else:
+            deps.append(temp)
+    return deps

--- a/rpg/spec.py
+++ b/rpg/spec.py
@@ -66,7 +66,7 @@ class Subpackage(object):
         self.BuildRequires = set()
         self.Requires = set()
         self.Provides = set()
-        self.files = []
+        self.files = set()
         self.changelog = []
         self.prep = Command()
         self.build = Command()
@@ -111,7 +111,7 @@ class Subpackage(object):
             if str(value):
                 if isinstance(value, Command):
                     block += '%' + ordered_key + '\n' + str(value) + '\n\n'
-                elif isinstance(value, list):
+                elif (isinstance(value, list) or (isinstance(value, set))):
                     block += '%' + ordered_key + '\n' + '\n'.join(
                         [(val[1] + " " if val[1] else "") + str(val[0])
                             for val in value]) + '\n\n' if value else ""
@@ -129,7 +129,7 @@ class Subpackage(object):
                 f[1].append("%doc")
                 break
         else:
-            self.files.append((file, ["%doc"], None))
+            self.files.add((file, ["%doc"], None))
 
 
 class Spec(Subpackage):

--- a/tests/project/autotools/configure.ac
+++ b/tests/project/autotools/configure.ac
@@ -1,0 +1,60 @@
+This document is purely for testig purposes, please do not take it seriously
+============================================================================
+
+Variables for tests:
+
+VAR_TEST6 = [test6 > test5]
+
+VAR_TEST7 = [
+			test7.1
+			[test7.2]
+]
+
+VAR_TEST8.1 = "test8.1 = doNotKnowIfViableButItWorks [$VAR_TEST8.2]"
+
+VAR_TEST8.2 = "test8.2"
+
+
+Something to be skipped:
+
+AC_MSG_CHECKING([For something 0.5.3 ABI break])
+AC_TRY_COMPILE([#include <stdlib.h>
+#include <something/sack.h>],
+               [hy_sack_create(NULL, NULL, NULL, 0); return 0;],
+               [AC_MSG_RESULT([no]); BUILDOPT_SOMETHING_SACK_CREATE2=0],
+               [AC_MSG_RESULT([yes]); BUILDOPT_SOMETHING_SACK_CREATE2=1])
+AC_DEFINE_UNQUOTED(BUILDOPT_SOMETHING_SACK_CREATE2, $BUILDOPT_SOMETHING_SACK_CREATE2, [something ABI change])
+AC_PATH_PROG([XSLTPROC], [xsltproc])
+AC_ARG_ENABLE(dnf-yumdb, AS_HELP_STRING([--enable-dnf-yumdb],[use dnf/yumdb instead of yum/yumdb @<:@default=yes@:>@]),
+              enable_dnf_yumdb=$enableval,enable_dnf_yumdb=yes)
+if test x$enable_dnf_yumdb = xyes; then
+  AC_DEFINE_UNQUOTED(BUILDOPT_USE_DNF_YUMDB,1,[Use dnf/yumdb instead of yum/yumdb])
+fi
+
+Tests:
+
+PKG_CHECK_MODULES(TEST1, test1 >= 2.36.0)
+
+PKG_CHECK_MODULES(TEST2,
+				  test2.1 >= test1.0
+				  test2.2)
+
+PKG_CHECK_MODULES(TEST3, test3.1 >= 0.4.6 [test3.2 >= 1.7.11]
+						 test3.3 >= 4.11.0, useless text)
+
+
+PKG_CHECK_MODULES(EMPTYTEST, )
+
+PKG_CHECK_MODULES(TEST4, test4 <= test5, another useless text, and another)
+
+PKG_CHECK_MODULES(TEST5, test5.1
+						 [ test5.2 ]
+					   , pure uselessness)
+
+PKG_CHECK_MODULES(TEST6, [$VAR_TEST6])
+
+PKG_CHECK_MODULES(TEST7, [$VAR_TEST7] test7.3)
+
+PKG_CHECK_MODULES(TEST8, [$VAR_TEST8.1])
+
+PKG_CHECK_MODULES(TEST9, ,PKG_CHECK_MODULES(TEST9, test9.1), PKG_CHECK_MODULES(TEST9, test9.2))

--- a/tests/project/c/CMakeLists.txt
+++ b/tests/project/c/CMakeLists.txt
@@ -1,0 +1,14 @@
+#ENABLE_TESTING
+
+# something ENABLE_TESTING
+
+# something [[ENABLE_TESTING]]
+
+#[[
+ENABLE_TESTING
+]]
+
+#[[something ENABLE_TESTING]]
+
+# Comment line below for tests to fail
+ENABLE_TESTING

--- a/tests/unit/test_functional.py
+++ b/tests/unit/test_functional.py
@@ -47,9 +47,9 @@ class FunctionalTest(RpgTestCase):
         base.run_compiled_source_analysis()
         base.install_project()
         base.run_installed_source_analysis()
-        self.assertEqual([
+        self.assertEqual(set([
             ("/hello", None, None),
             ("/__pycache__/", r"%exclude", None)
-        ].sort(), base.spec.files.sort())
+        ]), base.spec.files)
         base.build_srpm()
         self.assertTrue(base.srpm_path.exists())

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -109,7 +109,7 @@ class FindPatchPluginTest(PluginTestCase):
                     ('/setuptools/__pycache__/', '%exclude', None),
                     ('/autotools/__pycache__/', '%exclude', None)]
         sorted_files = sorted(files + excludes, key=lambda e: e[0])
-        self.assertEqual(self.spec.files,
+        self.assertEqual(sorted(list(self.spec.files)),
                          sorted_files)
 
     def test_find_translation_file(self):
@@ -117,8 +117,7 @@ class FindPatchPluginTest(PluginTestCase):
         plugin.installed(self.test_project_dir,
                          self.spec, self.sack)
         translation_file = ("-f %{CZ.mo}.lang")
-        self.assertEqual(self.spec.files[0],
-                         (translation_file, None, None))
+        self.assertTrue((translation_file, None, None) in self.spec.files)
 
     def test_find_library(self):
         plugin = FindLibraryPlugin()

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -91,6 +91,7 @@ class FindPatchPluginTest(PluginTestCase):
                  ('/py/requires/sourcecode2.py', None, None),
                  ('/mock_project/mock-1.0.tar.gz', None, None),
                  ('/c/CMakeCache.txt', None, None),
+                 ('/c/CMakeLists.txt', None, None),
                  ('/setuptools/setup.py', None, None),
                  ('/setuptools/testscript.py', None, None),
                  ('/autotools/configure.ac', None, None),
@@ -167,8 +168,10 @@ class FindPatchPluginTest(PluginTestCase):
         self.assertEqual(self.spec.required_files, expected)
         self.assertEqual(self.spec.build_required_files, expected)
 
-    def test_compiled(self):
+    def test_cmake(self):
         cmakeplug = CMakePlugin()
+        cmakeplug.patched(self.test_project_dir / "c", self.spec, self.sack)
+        self.assertEqual(str(self.spec.check), "make test")
         expected = set(["/usr/bin/gmake", "/usr/bin/file",
             "/usr/bin/makedepend", "/usr/bin/nosetests-3.4",
             "/usr/bin/python3.4"])

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -33,9 +33,11 @@ class SpecTest(RpgTestCase):
             "%check\nmake test\n\n"
         self.assertEqual(expected, str(self.spec))
 
-        self.spec.files = [("f1", "a1", ""),
-                           ("f2", "a2", ""),
-                           ("f3", "a3", "")]
+        self.spec.files = set([("f1", "a1", ""),
+                               ("f2", "a2", ""),
+                               ("f3", "a3", "")])
+        self.spec.files = sorted(list(self.spec.files))
+
         expected += "%files\n" \
                     "a1 f1\n"  \
                     "a2 f2\n"  \


### PR DESCRIPTION
I made short test similar to `setuptools plugin`. `Autotools plugin` is in fact scanning `configure.ac` file for dependencies, checking variables as well (and doing it recursively so there should be no problem). It includes optional and alternative dependencies as well. I am not sure what files are to be included that would not be found by other plugins. Anyway in my opinion it is doing what it is supposed to do. However when I tried to build some real packages I encountered few issues. Some packages have `configure.ac` file and no `CMakeLists.txt` or `Makefile` so autotools is not overrode by those and sets `spec.build` appropriately but:

* They already contain pure `configure` file so no `autoreconf` is needed
* Many contain `autogen.sh` script that does all the work

Should I adress those cases or suggest regular build for autotools supporting projects and let user modify it himself?